### PR TITLE
As header's height is `position:fixed`, compute the `#emptyviewlet`'s height dynamically using JS.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ Changelog
   [gbastien]
 - Make sure a:visited links in portlets have same color as a:link.
   [gbastien]
+- As header's height is `position:fixed`, compute the `#emptyviewlet`'s height
+  dynamically using JS.  Viewlet's height is computed by calling the JS method
+  directly in `empty.pt` so we do not see viewlet size changing.
+  [gbastien]
 
 2.7 (2019-01-28)
 ----------------

--- a/src/plonetheme/imioapps/browser/configure.zcml
+++ b/src/plonetheme/imioapps/browser/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="plonetheme.imioapps">
+
+    <!-- Publish static files -->
+    <browser:resourceDirectory
+      name="plonetheme.imioapps"
+      directory="static"
+      />
+
+</configure>

--- a/src/plonetheme/imioapps/browser/static/skin.js
+++ b/src/plonetheme/imioapps/browser/static/skin.js
@@ -1,0 +1,8 @@
+// as header is fixed, we need to compute emptyviewlet heights dynamically
+// in case header is two lines high
+
+function resizeHeader() {
+    $("#emptyviewlet").height($("#portal-header").height());
+}
+$(window).resize(resizeHeader);
+

--- a/src/plonetheme/imioapps/configure.zcml
+++ b/src/plonetheme/imioapps/configure.zcml
@@ -10,6 +10,7 @@
     <i18n:registerTranslations directory="locales" />
     <include file="profiles.zcml" />
     <include file="skins.zcml" />
+    <include package=".browser" />
 
     <!-- Zope 3 browser layer, this is needed so the skins are correctly considered as IDefaultPloneLayer skins -->
     <interface

--- a/src/plonetheme/imioapps/empty.pt
+++ b/src/plonetheme/imioapps/empty.pt
@@ -1,2 +1,5 @@
 <div id="emptyviewlet">
+    <script>
+        resizeHeader();
+    </script>
 </div>

--- a/src/plonetheme/imioapps/profiles.zcml
+++ b/src/plonetheme/imioapps/profiles.zcml
@@ -95,4 +95,14 @@
            import_steps="plone.app.registry" />
     </genericsetup:upgradeSteps>
 
+    <genericsetup:upgradeSteps
+       source="2200"
+       destination="2300"
+       profile="plonetheme.imioapps:default">
+       <genericsetup:upgradeDepends
+           title="Apply jsregistry.xml that adds JS that compute fixed header height"
+           description=""
+           import_steps="jsregistry" />
+    </genericsetup:upgradeSteps>
+
 </configure>

--- a/src/plonetheme/imioapps/profiles/default/jsregistry.xml
+++ b/src/plonetheme/imioapps/profiles/default/jsregistry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+ <javascript cacheable="True"
+             compression="safe"
+             cookable="False"
+             enabled="True"
+             expression=""
+             inline="False"
+             id="++resource++plonetheme.imioapps/skin.js"/>
+
+</object>

--- a/src/plonetheme/imioapps/profiles/default/metadata.xml
+++ b/src/plonetheme/imioapps/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2200</version>
+  <version>2300</version>
 </metadata>

--- a/src/plonetheme/imioapps/skins/imioapps_styles/imioapps.css.dtml
+++ b/src/plonetheme/imioapps/skins/imioapps_styles/imioapps.css.dtml
@@ -1352,10 +1352,6 @@ body.template-manage-viewlets div#portal-header {
    position: relative;
 
 }
-/* fixed header insert padding at top of emptyviewlet inserted as second element in portal-top */
-#portal-top div#emptyviewlet {
-    padding-top: 47px;
-}
 
 /* tooltip for collective.contact.core */
 .tooltip.pb-ajax {


### PR DESCRIPTION
Viewlet's height is computed by calling the JS method directly in `empty.pt` so we do not see viewlet size changing.
See #MOD-710