### PR TITLE
SUP-51123 Change state color for authorized and refused

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.63 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- SUP-51123 Change state color for authorized and refused
+  [jchandelle]
 
 
 2.62 (2026-04-14)

--- a/src/plonetheme/imioapps/skins/urbanskin_styles/urbanskin.css.dtml
+++ b/src/plonetheme/imioapps/skins/urbanskin_styles/urbanskin.css.dtml
@@ -425,6 +425,16 @@ td div.parcel-action {
     background: white;
 }
 
+.urban_state_authorized{
+    background-color: green;
+    color: white
+}
+
+.urban_state_refused{
+    background-color: red;
+    color: white
+}
+
 div.parcel-action{
     float: left;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated state indicator colors to provide distinct visual differentiation: "authorized" now shows with a green background and white text; "refused" now shows with a red background and white text.
* **Documentation**
  * Added changelog entry noting the updated colors for the "authorized" and "refused" states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->